### PR TITLE
two syntax changes

### DIFF
--- a/R/Accuracy.R
+++ b/R/Accuracy.R
@@ -140,7 +140,7 @@ accuracy <- function(data, group, opts, choice, none) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }

--- a/R/F1.R
+++ b/R/F1.R
@@ -137,7 +137,7 @@ f1 <- function(data, group, opts, choice, none) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }

--- a/R/KL.R
+++ b/R/KL.R
@@ -157,7 +157,7 @@ kl <- function(data, group, opts, choice, epsilon = NULL, base = NULL) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }
@@ -189,10 +189,10 @@ kl <- function(data, group, opts, choice, epsilon = NULL, base = NULL) {
       # create factor for actual choice
       alt = base::factor(
         {{ choice }},
-        levels = c(1:base::length(dplyr::select(., {{ opts }}))),
+        levels = c(base::seq_along(dplyr::select(., {{ opts }}))),
         labels = base::paste0(
           "Option_",
-          c(1:base::length(dplyr::select(
+          c(base::seq_along(dplyr::select(
             ., {{ opts }}
           )))
         )
@@ -210,8 +210,8 @@ kl <- function(data, group, opts, choice, epsilon = NULL, base = NULL) {
     dplyr::mutate(
       alt = base::factor(
         pred,
-        levels = c(1:base::length(dplyr::select(., {{ opts }}))),
-        labels = base::paste0("Option_", c(1:base::length(
+        levels = c(base::seq_along(dplyr::select(., {{ opts }}))),
+        labels = base::paste0("Option_", c(base::seq_along(
           dplyr::select(., {{ opts }})
         )))
       )

--- a/R/MAE.R
+++ b/R/MAE.R
@@ -91,7 +91,7 @@ mae <- function(data, group, opts, choice) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }
@@ -123,8 +123,8 @@ mae <- function(data, group, opts, choice) {
       # create factor
       merger = base::factor(
         {{ choice }},
-        levels = c(1:base::length(dplyr::select(., {{ opts }}))),
-        labels = c(1:base::length(dplyr::select(., {{ opts }})))
+        levels = c(base::seq_along(dplyr::select(., {{ opts }}))),
+        labels = c(base::seq_along(dplyr::select(., {{ opts }})))
       )
     ) %>%
     dplyr::group_by(dplyr::pick({{ group }})) %>%
@@ -154,7 +154,7 @@ mae <- function(data, group, opts, choice) {
       # change labeling
       alt = base::substr(alt, 1, (base::nchar(alt) - base::nchar("_mean"))),
       # create merger variable
-      merger = base::rep(1:base::length(dplyr::select(data, {{ opts }})),
+      merger = base::rep(base::seq_along(dplyr::select(data, {{ opts }})),
         length.out = base::length(alt)
       )
     ))

--- a/R/MHP.R
+++ b/R/MHP.R
@@ -90,7 +90,7 @@ mhp <- function(data, group, opts, choice) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }
@@ -142,7 +142,7 @@ mhp <- function(data, group, opts, choice) {
     base::unname()
 
   # assign correct hit probability
-  for (j in 1:nrow(data)) {
+  for (j in base::seq_len(base::nrow(data))) {
     data$mhp[j] <- base::unlist(data[j, choi[j]])
   }
 

--- a/R/MarkSim.R
+++ b/R/MarkSim.R
@@ -121,7 +121,7 @@ marksim <- function(data, group, opts,
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }
@@ -138,7 +138,7 @@ marksim <- function(data, group, opts,
   }
 
   # method can only be 'sop' or 'fc'
-  if ((method != "sop") & (method != "fc")) {
+  if ((method != "sop") && (method != "fc")) {
     base::stop(
       "Error: 'method' is wrong, please choose between",
       " 'sop' and 'fc'!"
@@ -190,7 +190,7 @@ marksim <- function(data, group, opts,
     return(data %>%
       dplyr::mutate(pred = base::max.col(dplyr::across({{ opts }}))) %>%
       mutate(pred = factor(pred,
-        levels = c(1:base::length(dplyr::select(., {{ opts }}))),
+        levels = c(base::seq_along(dplyr::select(., {{ opts }}))),
         labels = c(data %>% dplyr::select({{ opts }}) %>%
           base::colnames())
       ))

--- a/R/MedAE.R
+++ b/R/MedAE.R
@@ -91,7 +91,7 @@ medae <- function(data, group, opts, choice) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }
@@ -123,8 +123,8 @@ medae <- function(data, group, opts, choice) {
       # create factor
       merger = base::factor(
         {{ choice }},
-        levels = c(1:base::length(dplyr::select(., {{ opts }}))),
-        labels = c(1:base::length(dplyr::select(., {{ opts }})))
+        levels = c(base::seq_along(dplyr::select(., {{ opts }}))),
+        labels = c(base::seq_along(dplyr::select(., {{ opts }})))
       )
     ) %>%
     dplyr::group_by(dplyr::pick({{ group }})) %>%
@@ -158,7 +158,7 @@ medae <- function(data, group, opts, choice) {
         alt, 1,
         (base::nchar(alt) - base::nchar("_mean"))
       ),
-      merger = base::rep(1:base::length(dplyr::select(data, {{ opts }})),
+      merger = base::rep(base::seq_along(dplyr::select(data, {{ opts }})),
         length.out = base::length(alt)
       ) # create merger
     ))

--- a/R/Precision.R
+++ b/R/Precision.R
@@ -135,7 +135,7 @@ precision <- function(data, group, opts, choice, none) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }

--- a/R/RMSE.R
+++ b/R/RMSE.R
@@ -95,7 +95,7 @@ rmse <- function(data, group, opts, choice) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }
@@ -127,8 +127,8 @@ rmse <- function(data, group, opts, choice) {
       # factorize choice
       merger = base::factor(
         {{ choice }},
-        levels = c(1:base::length(dplyr::select(., {{ opts }}))),
-        labels = c(1:base::length(dplyr::select(., {{ opts }})))
+        levels = c(base::seq_along(dplyr::select(., {{ opts }}))),
+        labels = c(base::seq_along(dplyr::select(., {{ opts }})))
       )
     ) %>%
     dplyr::group_by(dplyr::pick({{ group }})) %>%
@@ -160,7 +160,7 @@ rmse <- function(data, group, opts, choice) {
       # adjust labeling
       alt = base::substr(alt, 1, (base::nchar(alt) - base::nchar("_mean"))),
       # prepare merge helper variable
-      merger = base::rep(1:base::length(dplyr::select(data, {{ opts }})),
+      merger = base::rep(base::seq_along(dplyr::select(data, {{ opts }})),
         length.out = base::length(alt)
       )
     ))

--- a/R/Reach.R
+++ b/R/Reach.R
@@ -99,7 +99,7 @@ reach <- function(data, group, none, opts) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }

--- a/R/Recall.R
+++ b/R/Recall.R
@@ -134,7 +134,7 @@ recall <- function(data, group, opts, choice, none) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }

--- a/R/Specificity.R
+++ b/R/Specificity.R
@@ -134,7 +134,7 @@ specificity <- function(data, group, opts, choice, none) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }

--- a/R/att_imp.R
+++ b/R/att_imp.R
@@ -105,7 +105,7 @@ att_imp <- function(data, group = NULL, attrib, coding,
 
   # test numeric input for coding
   if (!(base::is.null(coding))) {
-    for (i in 1:base::length(coding)) {
+    for (i in base::seq_along(coding)) {
       if (!(base::is.numeric(coding[i]))) {
         base::stop("Error: 'coding' only can have numeric input!")
       }
@@ -121,14 +121,14 @@ att_imp <- function(data, group = NULL, attrib, coding,
 
 
   # test input of interpolate levels
-  if (!(base::is.list(interpolate.levels)) &
+  if (!(base::is.list(interpolate.levels)) &&
     !(base::is.null(interpolate.levels))) {
     base::stop("Error: Input of 'interpolate.levels' has to be a list!")
   }
 
   # test variables of interpolate.levels
   if (!(base::is.null(interpolate.levels))) {
-    for (tt in 1:base::length(interpolate.levels)) {
+    for (tt in base::seq_along(interpolate.levels)) {
       lng <- base::length(interpolate.levels[[tt]])
 
       for (lng_lev in 1:lng) {
@@ -143,7 +143,7 @@ att_imp <- function(data, group = NULL, attrib, coding,
   }
 
   # interpolate.levels can not be larger than number of attributes
-  if (!base::is.null(interpolate.levels) &
+  if (!base::is.null(interpolate.levels) &&
     (base::length(interpolate.levels) > base::length(attrib))) {
     base::stop(
       "Error: List of 'interpolate.levels' can not be larger than list of 'attrib'!"
@@ -153,20 +153,20 @@ att_imp <- function(data, group = NULL, attrib, coding,
   # check length of 'attrib' and coding
   # test input of list in prod.levels
   if (!(base::is.null(attrib))) {
-    for (tt in 1:base::length(attrib)) {
-      if (base::length(attrib[[tt]]) == 1 & coding[tt] == 0) {
+    for (tt in base::seq_along(attrib)) {
+      if (base::length(attrib[[tt]]) == 1 && coding[tt] == 0) {
         base::stop(
           "Error: If attribute is part-worth coded at least 2 attribute levels need to be specified!"
         )
       }
 
-      if (base::length(attrib[[tt]]) > 1 & coding[tt] == 1) {
+      if (base::length(attrib[[tt]]) > 1 && coding[tt] == 1) {
         base::stop(
           "Error: If attribute is linear coded only one attribute level needs to be specified!"
         )
       }
 
-      if (base::length(attrib[[tt]]) == 1 & coding[tt] == 2) {
+      if (base::length(attrib[[tt]]) == 1 && coding[tt] == 2) {
         base::stop(
           "Error: If attribute is piecewise coded at least 2 attribute levels need to be specified!"
         )
@@ -175,14 +175,14 @@ att_imp <- function(data, group = NULL, attrib, coding,
   }
 
   # if 1 is coded, interpolate.levels needs to be specified
-  if (base::any(coding == 1) & base::is.null(interpolate.levels)) {
+  if (base::any(coding == 1) && base::is.null(interpolate.levels)) {
     base::stop(
       "Error: 'interpolate.levels' is missing!"
     )
   }
 
   # if no 1 coded interpolate.levels is not needed
-  if (!base::any(coding == 1) & !base::is.null(interpolate.levels)) {
+  if (!base::any(coding == 1) && !base::is.null(interpolate.levels)) {
     base::stop(
       "Error: 'interpolate.levels' only needs to be specified for linear coded variables!"
     )
@@ -190,7 +190,7 @@ att_imp <- function(data, group = NULL, attrib, coding,
 
   # number of coding larger than length of interpolate levels
 
-  if (!base::is.null(interpolate.levels) & (base::sum(coding == 1) != base::length(interpolate.levels))) {
+  if (!base::is.null(interpolate.levels) && (base::sum(coding == 1) != base::length(interpolate.levels))) {
     base::stop(
       "Error: Number of linear coded variables is not equal to length of 'interpolate.levels'!"
     )
@@ -202,7 +202,7 @@ att_imp <- function(data, group = NULL, attrib, coding,
   }
 
   # test whether res is correctly specified
-  if ((res != "agg") & (res != "ind")) {
+  if ((res != "agg") && (res != "ind")) {
     base::stop(
       "Error: 'res' can only be set to 'agg' or 'ind'!"
     )
@@ -217,7 +217,7 @@ att_imp <- function(data, group = NULL, attrib, coding,
   }
 
   # can not specify res to 'ind' and specify group
-  if ((res == "ind") & !base::missing(group)) {
+  if ((res == "ind") && !base::missing(group)) {
     stop("Error: Can not speficy 'group' if 'res' is set to 'ind'!")
   }
 
@@ -235,8 +235,8 @@ att_imp <- function(data, group = NULL, attrib, coding,
 
     new <- c(new, base::paste0("att_imp_", i))
 
-    for (j in 1:base::nrow(data)) {
-      if (coding[i] == 0 | coding[i] == 2) {
+    for (j in base::seq_len(base::nrow(data))) {
+      if (coding[i] == 0 || coding[i] == 2) {
         data[j, base::paste0("att_imp_", i)] <- base::abs(base::diff(base::range(data[j, vars])))
       }
 

--- a/R/createHOT.R
+++ b/R/createHOT.R
@@ -221,7 +221,7 @@ createHOT <- function(data, id, none = NULL,
 
   # test numeric input for coding
   if (!(base::is.null(coding))) {
-    for (i in 1:base::length(coding)) {
+    for (i in base::seq_along(coding)) {
       if (!(base::is.numeric(coding[i]))) {
         base::stop("Error: 'coding' only can have numeric input!")
       }
@@ -229,8 +229,8 @@ createHOT <- function(data, id, none = NULL,
   }
 
   if (!(base::is.null(coding))) {
-    if (base::any(coding == 1) | base::any(coding == 2)) {
-      for (q in 1:base::length(prod.levels)) {
+    if (base::any(coding == 1) || base::any(coding == 2)) {
+      for (q in base::seq_along(prod.levels)) {
         if (base::any(is.character(prod.levels[[q]]))) {
           base::stop(
             "Error: Input 'prod.levels' has to be numeric if linear or ",
@@ -254,7 +254,7 @@ createHOT <- function(data, id, none = NULL,
   }
 
   # test whether method is correctly specified
-  if ((method != "ACBC") & (method != "CBC") & (method != "MaxDiff")) {
+  if ((method != "ACBC") && (method != "CBC") && (method != "MaxDiff")) {
     base::stop(
       "Error: Please choose one of the supported methods: 'MaxDiff',",
       " 'ACBC', 'CBC'!"
@@ -262,34 +262,34 @@ createHOT <- function(data, id, none = NULL,
   }
 
   # coding required for CBC or ACBC
-  if (method == "CBC" | method == "ACBC") {
+  if (method == "CBC" || method == "ACBC") {
     if (base::missing(coding)) {
       stop("Error: 'coding' is missing!")
     }
   }
 
   # test whether coding is empty if method == MaxDiff
-  if (method == "MaxDiff" & !(base::is.null(coding))) {
+  if (method == "MaxDiff" && !(base::is.null(coding))) {
     base::stop("Error: 'coding' is not required for ", method, "!")
   }
 
   # test whether interpolate levels is empty is specified if method == MaxDiff
-  if (method == "MaxDiff" & !(base::is.null(interpolate.levels))) {
+  if (method == "MaxDiff" && !(base::is.null(interpolate.levels))) {
     base::stop("Error: 'interpolate.levels' is not required for ", method, "!")
   }
 
   # test whether piece.p is empty is specified if method == MaxDiff
-  if (method == "MaxDiff" & !(base::is.null(piece.p))) {
+  if (method == "MaxDiff" && !(base::is.null(piece.p))) {
     base::stop("Error: 'piece.p' is not required for ", method, "!")
   }
 
   # test whether lin.p is empty is specified if method == MaxDiff
-  if (method == "MaxDiff" & !(base::is.null(lin.p))) {
+  if (method == "MaxDiff" && !(base::is.null(lin.p))) {
     base::stop("Error: 'lin.p' is not required for ", method, "!")
   }
 
   # test whether coding only includes 0, 1, 2
-  if ((method == "ACBC" | method == "CBC") &
+  if ((method == "ACBC" || method == "CBC") &&
     base::any(coding != 0 & coding != 1 & coding != 2)) {
     base::stop(
       "Error: Please only use '0' (for part-worth), '1' (for linear)",
@@ -306,25 +306,25 @@ createHOT <- function(data, id, none = NULL,
   }
 
   # test whether CBC is specified and no coding equal to 2
-  if (method == "CBC" & base::any(coding == 2)) {
+  if (method == "CBC" && base::any(coding == 2)) {
     base::stop("Error: Piecewise coding not possible for ", method, "!")
   }
 
   # test whether CBC is used, one variable linear coded however
   # position not specified (or other way around)
-  if (method == "CBC" & !(base::any(coding == 1)) & !(base::is.null(lin.p))) {
+  if (method == "CBC" && !(base::any(coding == 1)) && !(base::is.null(lin.p))) {
     base::stop("Error: 'lin.p' specified but no '1' in coding!")
   }
 
   # test whether ACBC is used, one variable linear coded however
   # position not specified  (or other way around)
-  if (method == "ACBC" & !(base::any(coding == 1)) & !(base::is.null(lin.p))) {
+  if (method == "ACBC" && !(base::any(coding == 1)) && !(base::is.null(lin.p))) {
     base::stop("Error: 'lin.p' specified but no '1' in coding!")
   }
 
   # test whether ACBC is used, one variable piecewise coded however
   # position not specified  (or other way around)
-  if (method == "ACBC" & !(base::any(coding == 2)) &
+  if (method == "ACBC" && !(base::any(coding == 2)) &&
     !(base::is.null(piece.p))) {
     base::stop("Error: 'piece.p' specified but no '2' in coding!")
   }
@@ -336,7 +336,7 @@ createHOT <- function(data, id, none = NULL,
 
   # test variables of prod.levels
   if (!(base::is.null(prod.levels))) {
-    for (tt in 1:base::length(prod.levels)) {
+    for (tt in base::seq_along(prod.levels)) {
       lng <- base::length(prod.levels[[tt]])
       if (lng == 1) {
         if (!base::is.na(prod.levels[[tt]])) {
@@ -352,7 +352,7 @@ createHOT <- function(data, id, none = NULL,
 
       if (lng > 1) {
         for (lng_lev in 1:lng) {
-          if (coding[lng_lev] != 1 & coding[lng_lev] != 2) {
+          if (coding[lng_lev] != 1 && coding[lng_lev] != 2) {
             if (!base::is.na(prod.levels[[tt]][lng_lev])) {
               var <- prod.levels[[tt]][lng_lev]
               if (!(base::is.numeric(data[[var]]))) {
@@ -369,14 +369,14 @@ createHOT <- function(data, id, none = NULL,
   }
 
   # test input of interpolate levels
-  if (!(base::is.list(interpolate.levels)) &
+  if (!(base::is.list(interpolate.levels)) &&
     !(base::is.null(interpolate.levels))) {
     base::stop("Error: Input of 'interpolate.levels' has to be a list!")
   }
 
   # test variables of interpolate.levels
   if (!(base::is.null(interpolate.levels))) {
-    for (tt in 1:base::length(interpolate.levels)) {
+    for (tt in base::seq_along(interpolate.levels)) {
       lng <- base::length(interpolate.levels[[tt]])
 
       for (lng_lev in 1:lng) {
@@ -393,7 +393,7 @@ createHOT <- function(data, id, none = NULL,
 
   # test lin.p variables format
   if (!(base::is.null(lin.p))) {
-    for (ll in 1:base::length(lin.p)) {
+    for (ll in base::seq_along(lin.p)) {
       if (!base::is.numeric(data[[lin.p[ll]]])) {
         base::stop("Error: Variables included in 'lin.p' have to be numeric!")
       }
@@ -402,28 +402,28 @@ createHOT <- function(data, id, none = NULL,
 
   # test whether coding indicated linear coded variable, however,
   # not specified
-  if (base::any(coding == 1) & base::is.null(lin.p)) {
+  if (base::any(coding == 1) && base::is.null(lin.p)) {
     base::stop("Error: Please specify 'lin.p'!")
   }
 
-  if (base::any(coding == 1 | coding == 2) & base::missing(interpolate.levels)) {
+  if (base::any(coding == 1 | coding == 2) && base::missing(interpolate.levels)) {
     base::stop("Error: 'interpolate.levels' is missing!")
   }
 
   # test whether coding indicated piecewise coded variable, however,
   # not specified
-  if (base::any(coding == 2) & base::is.null(piece.p)) {
+  if (base::any(coding == 2) && base::is.null(piece.p)) {
     base::stop("Error: Please specify 'piece.p'!")
   }
 
   # test input of piece.p
-  if (!(base::is.null(piece.p)) & !(base::is.list(piece.p))) {
+  if (!(base::is.null(piece.p)) && !(base::is.list(piece.p))) {
     base::stop("Error: Input of 'piece.p' has to be a list!")
   }
 
   # test variables specified in piece.p
   if (!(base::is.null(piece.p))) {
-    for (tt in 1:base::length(piece.p)) {
+    for (tt in base::seq_along(piece.p)) {
       lng <- base::length(piece.p[[tt]])
       if (lng == 1) {
         var <- piece.p[[tt]]
@@ -495,13 +495,13 @@ createHOT <- function(data, id, none = NULL,
   df[base::is.na(df)] <- 0
 
 
-  for (row in 1:base::nrow(df)) { # repeat procedure for each row
+  for (row in base::seq_len(base::nrow(df))) { # repeat procedure for each row
     for (q in 1:prod) { # and for each prod
       helper <- 1 # define helper variables
       linear_pos <- 1 # define helper variables
 
       # loop for each level specified for an alternative (prod)
-      for (pq in 1:base::length(prod.levels[[q]])) {
+      for (pq in base::seq_along(prod.levels[[q]])) {
         if (!base::is.na(prod.levels[[q]][pq])) {
           if (coding[pq] == 0) { # only run for part-worth coded variable
 

--- a/R/freqAssort.R
+++ b/R/freqAssort.R
@@ -98,7 +98,7 @@ freqassort <- function(data, group, none, opts) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }

--- a/R/hitrate.R
+++ b/R/hitrate.R
@@ -95,7 +95,7 @@ hitrate <- function(data, group, opts, choice) {
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }

--- a/R/prob_scores.R
+++ b/R/prob_scores.R
@@ -118,7 +118,7 @@ prob_scores <- function(data, group = NULL, items, set.size,
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       base::stop("Error: 'items' has to be numeric!")
     }
@@ -144,14 +144,14 @@ prob_scores <- function(data, group = NULL, items, set.size,
   }
 
   # test whether res is correctly specified
-  if ((res != "agg") & (res != "ind")) {
+  if ((res != "agg") && (res != "ind")) {
     base::stop(
       "Error: 'res' can only be set to 'agg' or 'ind'!"
     )
   }
 
   # can not specify res to 'ind' and specify group
-  if ((res == "ind") & !base::missing(group)) {
+  if ((res == "ind") && !base::missing(group)) {
     stop("Error: Can not speficy 'group' if 'res' is set to 'ind'!")
   }
 

--- a/R/turf.R
+++ b/R/turf.R
@@ -185,7 +185,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
 
   # prohib has to be part of opts
   if (!base::is.null(prohib)) {
-    for (i in 1:base::length(prohib)) {
+    for (i in base::seq_along(prohib)) {
       if (!base::all(prohib[[i]] %in% (data %>% dplyr::select(., {{ opts }}) %>%
         base::colnames()))) {
         base::stop("Error: 'prohib' has to be part of 'opts'!")
@@ -195,7 +195,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
 
   # fixed can not be larger than size
   if (!base::is.null(prohib)) {
-    for (i in 1:base::length(prohib)) {
+    for (i in base::seq_along(prohib)) {
       if (length(prohib[[i]]) > size) {
         stop("Error: 'prohib' can not be larger than 'size'!")
       }
@@ -210,7 +210,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
 
   # error if prohib and fixed are exactly the same
   if (!base::is.null(prohib) & !base::is.null(fixed)) {
-    for (i in 1:base::length(prohib)) {
+    for (i in base::seq_along(prohib)) {
       if (base::all(prohib[[i]] %in% fixed)) {
         base::stop("Error: 'prohib' and 'fixed' have to be different!")
       }
@@ -224,7 +224,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       stop("Error: 'opts' has to be numeric!")
     }
@@ -283,7 +283,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
       # store column index with highest value
       dplyr::mutate(maximum = base::max.col(.))
 
-    for (row in 1:base::nrow(df)) { # loop for each row
+    for (row in base::seq_len(base::nrow(df))) { # loop for each row
       # loop for each column (except for last two --> thres and maximum)
       for (col in 1:(base::ncol(df) - 2)) {
         # only run if larger than threshold and if row maximum
@@ -307,7 +307,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
   # define new variable names
   var_names <- c(items, paste0("new_col_names_", c(1:size)))
   var_names <- base::make.unique(var_names, sep = "...")
-  var_names <- var_names[-c(1:length(items))]
+  var_names <- var_names[-c(base::seq_along(items))]
 
   # create combos
   # create all possible combinations
@@ -334,7 +334,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
   }
 
   if (!base::is.null(prohib)) {
-    for (i in 1:length(prohib)) {
+    for (i in base::seq_along(prohib)) {
       prohibitions <- data %>%
         dplyr::select(tidyselect::all_of(prohib[[i]])) %>%
         base::colnames()
@@ -351,7 +351,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
   }
 
   # count reach and frequency for each
-  for (i in 1:nrow(combos)) {
+  for (i in base::seq_len(base::nrow(combos))) {
     combs <- base::unname(c(base::unlist(combos[i, ]))) # store the combos as vector
 
     # create combination and store the rowsum for that
@@ -368,7 +368,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
       dplyr::select(tidyselect::all_of(tidyselect::starts_with("comb."))) %>%
       # create the reach score
       dplyr::summarise(dplyr::across(
-        1:base::ncol(.),
+        base::seq_len(base::ncol(.)),
         ~ (base::sum(. > 0) / base::nrow(df)
           * 100)
       )) %>%
@@ -385,7 +385,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
       # only select the variables that start with comb. (see approach before)
       dplyr::select(tidyselect::all_of(tidyselect::starts_with("comb."))) %>%
       # create frequency score
-      dplyr::summarise(dplyr::across(1:base::ncol(.), ~ base::mean(.x))) %>%
+      dplyr::summarise(dplyr::across(base::seq_len(base::ncol(.)), ~ base::mean(.x))) %>%
       base::t() %>% # transpose
       base::as.data.frame() %>% # store as data frame
       dplyr::rename_all(., ~"freq") %>% # rename variable into 'freq'
@@ -410,7 +410,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
     base::cbind(combos, .) # bind with combos
 
   # prepare the binary coding
-  for (i in 1:base::nrow(new_df)) { # loop for each row
+  for (i in base::seq_len(base::nrow(new_df))) { # loop for each row
     for (j in 1:size) { # repeat for each assortment
       new_df[i, new_df[i, j]] <- 1 # store 1
     }
@@ -421,7 +421,7 @@ turf <- function(data, opts, none, size, fixed = NULL, prohib = NULL,
     dplyr::mutate(combo = 0)
 
   # store the names in the variable for merging purposes
-  for (i in 1:base::nrow(new_df)) { # loop for merging purposes
+  for (i in base::seq_len(base::nrow(new_df))) { # loop for merging purposes
     new_df[i, "combo"] <- base::paste0(
       "comb.",
       base::paste0(new_df[i, c(1:size)],

--- a/R/zc_diffs.R
+++ b/R/zc_diffs.R
@@ -154,7 +154,7 @@ zc_diffs <- function(data, group = NULL, attrib, coding, interpolate.levels = NU
 
   # test numeric input for coding
   if (!(base::is.null(coding))) {
-    for (i in 1:base::length(coding)) {
+    for (i in base::seq_along(coding)) {
       if (!(base::is.numeric(coding[i]))) {
         base::stop("Error: 'coding' only can have numeric input!")
       }
@@ -170,14 +170,14 @@ zc_diffs <- function(data, group = NULL, attrib, coding, interpolate.levels = NU
 
 
   # test input of interpolate levels
-  if (!(base::is.list(interpolate.levels)) &
+  if (!(base::is.list(interpolate.levels)) &&
     !(base::is.null(interpolate.levels))) {
     base::stop("Error: Input of 'interpolate.levels' has to be a list!")
   }
 
   # test variables of interpolate.levels
   if (!(base::is.null(interpolate.levels))) {
-    for (tt in 1:base::length(interpolate.levels)) {
+    for (tt in base::seq_along(interpolate.levels)) {
       lng <- base::length(interpolate.levels[[tt]])
 
       for (lng_lev in 1:lng) {
@@ -192,7 +192,7 @@ zc_diffs <- function(data, group = NULL, attrib, coding, interpolate.levels = NU
   }
 
   # interpolate.levels can not be larger than number of attributes
-  if (!base::is.null(interpolate.levels) &
+  if (!base::is.null(interpolate.levels) &&
     (base::length(interpolate.levels) > base::length(attrib))) {
     base::stop(
       "Error: List of 'interpolate.levels' can not be larger than list of 'attrib'!"
@@ -202,20 +202,20 @@ zc_diffs <- function(data, group = NULL, attrib, coding, interpolate.levels = NU
   # check length of 'attrib' and coding
   # test input of list in prod.levels
   if (!(base::is.null(attrib))) {
-    for (tt in 1:base::length(attrib)) {
-      if (base::length(attrib[[tt]]) == 1 & coding[tt] == 0) {
+    for (tt in base::seq_along(attrib)) {
+      if (base::length(attrib[[tt]]) == 1 && coding[tt] == 0) {
         base::stop(
           "Error: If attribute is part-worth coded at least 2 attribute levels need to be specified!"
         )
       }
 
-      if (base::length(attrib[[tt]]) > 1 & coding[tt] == 1) {
+      if (base::length(attrib[[tt]]) > 1 && coding[tt] == 1) {
         base::stop(
           "Error: If attribute is linear coded only one attribute level needs to be specified!"
         )
       }
 
-      if (base::length(attrib[[tt]]) == 1 & coding[tt] == 2) {
+      if (base::length(attrib[[tt]]) == 1 && coding[tt] == 2) {
         base::stop(
           "Error: If attribute is piecewise coded at least 2 attribute levels need to be specified!"
         )
@@ -224,14 +224,14 @@ zc_diffs <- function(data, group = NULL, attrib, coding, interpolate.levels = NU
   }
 
   # if 1 is coded, interpolate.levels needs to be specified
-  if (base::any(coding == 1) & base::is.null(interpolate.levels)) {
+  if (base::any(coding == 1) && base::is.null(interpolate.levels)) {
     base::stop(
       "Error: 'interpolate.levels' is missing!"
     )
   }
 
   # if no 1 coded interpolate.levels is not needed
-  if (!base::any(coding == 1) & !base::is.null(interpolate.levels)) {
+  if (!base::any(coding == 1) && !base::is.null(interpolate.levels)) {
     base::stop(
       "Error: 'interpolate.levels' only needs to be specified for linear coded variables!"
     )
@@ -239,7 +239,7 @@ zc_diffs <- function(data, group = NULL, attrib, coding, interpolate.levels = NU
 
   # number of coding larger than length of interpolate levels
 
-  if (!base::is.null(interpolate.levels) & (base::sum(coding == 1) != base::length(interpolate.levels))) {
+  if (!base::is.null(interpolate.levels) && (base::sum(coding == 1) != base::length(interpolate.levels))) {
     base::stop(
       "Error: Number of linear coded variables is not equal to length of 'interpolate.levels'!"
     )
@@ -259,14 +259,14 @@ zc_diffs <- function(data, group = NULL, attrib, coding, interpolate.levels = NU
   }
 
   # test whether res is correctly specified
-  if ((res != "agg") & (res != "ind")) {
+  if ((res != "agg") && (res != "ind")) {
     base::stop(
       "Error: 'res' can only be set to 'agg' or 'ind'!"
     )
   }
 
   # can not specify res to 'ind' and specify group
-  if ((res == "ind") & !base::missing(group)) {
+  if ((res == "ind") && !base::missing(group)) {
     stop("Error: Can not speficy 'group' if 'res' is set to 'ind'!")
   }
 
@@ -295,7 +295,7 @@ zc_diffs <- function(data, group = NULL, attrib, coding, interpolate.levels = NU
   att <- base::length(attrib)
 
   attrib_all <- c()
-  for (i in 1:base::length(attrib)) {
+  for (i in base::seq_along(attrib)) {
     attrib_all <- c(attrib_all, base::colnames(data[attrib[[i]]]))
   }
 
@@ -310,8 +310,8 @@ zc_diffs <- function(data, group = NULL, attrib, coding, interpolate.levels = NU
 
     new <- c(new, base::paste0("range_att_", i))
 
-    for (j in 1:base::nrow(data)) {
-      if (coding[i] == 0 | coding[i] == 2) {
+    for (j in base::seq_len(base::nrow(data))) {
+      if (coding[i] == 0 || coding[i] == 2) {
         data[j, base::paste0("range_att_", i)] <- base::abs(base::diff(base::range(data[j, vars])))
       }
 

--- a/R/zero_anchored.R
+++ b/R/zero_anchored.R
@@ -116,7 +116,7 @@ zero_anchored <- function(data, group = NULL, items,
     base::colnames()
 
   ## check whether variable is numeric
-  for (i in 1:base::length(alternatives)) {
+  for (i in base::seq_along(alternatives)) {
     if (!base::is.numeric(data[[alternatives[i]]])) {
       base::stop("Error: 'items' has to be numeric!")
     }
@@ -135,14 +135,14 @@ zero_anchored <- function(data, group = NULL, items,
   }
 
   # test whether res is correctly specified
-  if ((res != "agg") & (res != "ind")) {
+  if ((res != "agg") && (res != "ind")) {
     base::stop(
       "Error: 'res' can only be set to 'agg' or 'ind'!"
     )
   }
 
   # can not specify res to 'ind' and specify group
-  if ((res == "ind") & !base::missing(group)) {
+  if ((res == "ind") && !base::missing(group)) {
     stop("Error: Can not speficy 'group' if 'res' is set to 'ind'!")
   }
 
@@ -174,7 +174,7 @@ zero_anchored <- function(data, group = NULL, items,
     base::colnames(.)
 
 
-  for (i in 1:base::nrow(data)) {
+  for (i in base::seq_len(base::nrow(data))) {
     vec <- base::unname(base::unlist(c(data[i, var_items])))
 
     # data[i, var_items] <- NA

--- a/tests/testthat/test-ACBC_interpolate.R
+++ b/tests/testthat/test-ACBC_interpolate.R
@@ -8,7 +8,7 @@ test_that("Structure of DF", {
 
 test_that("Variables numeric", {
   names <- base::colnames(ACBC_interpolate)[-(base::which(base::colnames(ACBC_interpolate) == "Group"))]
-  for (i in 1:base::length(names)) {
+  for (i in base::seq_along(names)) {
     expect_true(!base::is.character(ACBC_interpolate[names[i]]))
   }
 })

--- a/tests/testthat/test-CBC.R
+++ b/tests/testthat/test-CBC.R
@@ -8,7 +8,7 @@ test_that("Structure of DF", {
 
 test_that("Variables numeric", {
   names <- base::colnames(CBC)[-(base::which(base::colnames(CBC) == "Group"))]
-  for (i in 1:base::length(names)) {
+  for (i in base::seq_along(names)) {
     expect_true(!base::is.character(CBC[names[i]]))
   }
 })

--- a/tests/testthat/test-CBC_lin.R
+++ b/tests/testthat/test-CBC_lin.R
@@ -8,7 +8,7 @@ test_that("Structure of DF", {
 
 test_that("Variables numeric", {
   names <- base::colnames(CBC_lin)[-(base::which(base::colnames(CBC_lin) == "Group"))]
-  for (i in 1:base::length(names)) {
+  for (i in base::seq_along(names)) {
     expect_true(!base::is.character(CBC_lin[names[i]]))
   }
 })

--- a/tests/testthat/test-MaxDiff.R
+++ b/tests/testthat/test-MaxDiff.R
@@ -8,7 +8,7 @@ test_that("Structure of DF", {
 
 test_that("Variables numeric", {
   names <- base::colnames(MaxDiff)[-(base::which(base::colnames(MaxDiff) == "Group"))]
-  for (i in 1:base::length(names)) {
+  for (i in base::seq_along(names)) {
     expect_true(!base::is.character(MaxDiff[names[i]]))
   }
 })


### PR DESCRIPTION
- use seq_* functions instead of 1: for safety
- use && & || for scalar conditionals

both are suggestions not required, tests passed.

I'm curious, is there any particular reason you use base:: for base R functions?

openjournals/joss-reviews/issues/6708